### PR TITLE
change singleton registration

### DIFF
--- a/src/BlacklistIpServiceProvider.php
+++ b/src/BlacklistIpServiceProvider.php
@@ -33,15 +33,6 @@ class BlacklistIpServiceProvider extends ServiceProvider
             ], 'migrations');
         }
 
-        $this->app->singleton(
-            'blacklist_ip.update_cloud_ips',
-            function($app) {
-                return new UpdateCloudIps(
-                    $app->make('config')->get('blacklist_ip')
-                );
-            }
-        );
-
         $this->commands([
             'blacklist_ip.update_cloud_ips'
         ]);
@@ -58,6 +49,10 @@ class BlacklistIpServiceProvider extends ServiceProvider
 
         $this->app->singleton('blacklist', function ($app) {
             return new Blacklist($app['config']->get('blacklist_ip'));
+        });
+
+        $this->app->singleton('blacklist_ip.update_cloud_ips', function($app) {
+            return new UpdateCloudIps($app['config']->get('blacklist_ip'));
         });
     }
 


### PR DESCRIPTION
There must have been a change between Laravel/Lumen 5.5 and 5.7 because when I run tests in the Lumen redirect project I get errors that class  `blacklist_ip.update_cloud_ips` can not be found. 

I believe that it is trying to register the commands before the singleton has registered. Moving the singleton to the `register` method resolves the issue, since `register` is called on all service providers before the `boot` method is called. https://lumen.laravel.com/docs/5.7/providers#the-register-method

Registering the command into the container earlier should not affect current functionality. Tests are still passing.